### PR TITLE
add log fetch support for multi container pods

### DIFF
--- a/pkg/models/event.go
+++ b/pkg/models/event.go
@@ -34,4 +34,6 @@ type EventDetails struct {
 	Critical     bool              `json:"critical"`
 	Timestamp    string            `json:"timestamp"`
 	EventType    EventCriticality  `json:"event_type"`
+	Phase        string            `json:"pod_phase"`
+	Status       string            `json:"pod_status"`
 }

--- a/pkg/processor/processor.go
+++ b/pkg/processor/processor.go
@@ -4,13 +4,24 @@ import (
 	"context"
 
 	"github.com/porter-dev/porter-agent/pkg/models"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
+type EnqueueDetailOptions struct {
+	ContainerNamesToFetchLogs []string
+}
+
 type Interface interface {
 	// Used in case of normal events to store and update logs
-	EnqueueDetails(context context.Context, object types.NamespacedName)
+	EnqueueDetails(context context.Context, object types.NamespacedName, options *EnqueueDetailOptions)
 	// to trigger actual request for porter server in case of
 	// a Delete or Failed/Unknown Phase
 	AddToWorkQueue(context context.Context, object types.NamespacedName, details models.EventDetails)
+}
+
+func (e *EnqueueDetailOptions) SetContainerName(podOptions *corev1.PodLogOptions) {
+	if len(e.ContainerNamesToFetchLogs) > 0 {
+		podOptions.Container = e.ContainerNamesToFetchLogs[0]
+	}
 }


### PR DESCRIPTION
also added few more attributes to the `EventDetails` model which the backend can safely ignore. I mostly for better contextual purposes when debugging or going though the redis logs at this stage while debugging. Can remove it in the long run.

Signed-off-by: Ishan Khare <me@ishankhare.dev>