### PR TITLE
rfac: track pods list by revision

### DIFF
--- a/api/server/handlers/log/get_pod_values.go
+++ b/api/server/handlers/log/get_pod_values.go
@@ -47,6 +47,7 @@ func (h *GetPodValuesHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) 
 		Start:     *req.StartRange,
 		End:       *req.EndRange,
 		PodPrefix: req.MatchPrefix,
+		Revision:  req.Revision,
 	})
 
 	if err != nil {

--- a/api/server/types/log.go
+++ b/api/server/types/log.go
@@ -28,6 +28,7 @@ type GetPodValuesRequest struct {
 	StartRange  *time.Time `schema:"start_range"`
 	EndRange    *time.Time `schema:"end_range"`
 	MatchPrefix string     `schema:"match_prefix"`
+	Revision    string     `schema:"revision"`
 }
 
 type GetRevisionValuesRequest struct {

--- a/pkg/logstore/logstore.go
+++ b/pkg/logstore/logstore.go
@@ -28,6 +28,7 @@ type LabelValueOptions struct {
 	Start     time.Time
 	End       time.Time
 	PodPrefix string
+	Revision  string
 }
 
 type LogStore interface {

--- a/pkg/logstore/lokistore/lokistore.go
+++ b/pkg/logstore/lokistore/lokistore.go
@@ -167,7 +167,7 @@ func (store *LokiStore) GetPodLabelValues(options logstore.LabelValueOptions) ([
 			Start: timestamppb.New(options.Start),
 			End:   timestamppb.New(options.End),
 			Groups: []string{
-				fmt.Sprintf(`{pod=~"%s.*"}`, options.PodPrefix),
+				fmt.Sprintf(`{pod=~"%s.*",helm_sh_revision="%s"}`, options.PodPrefix, options.Revision),
 			},
 		},
 	)

--- a/pkg/logstore/lokistore/lokistore.go
+++ b/pkg/logstore/lokistore/lokistore.go
@@ -157,9 +157,16 @@ func (store *LokiStore) Tail(options logstore.TailOptions, w logstore.Writer, st
 }
 
 func (store *LokiStore) GetPodLabelValues(options logstore.LabelValueOptions) ([]string, error) {
+	var groupString string
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 
 	defer cancel()
+
+	if options.Revision != "" {
+		groupString = fmt.Sprintf(`{pod=~"%s.*",helm_sh_revision="%s"}`, options.PodPrefix, options.Revision)
+	} else {
+		groupString = fmt.Sprintf(`{pod=~"%s.*"}`, options.PodPrefix)
+	}
 
 	seriesResp, err := store.querierClient.Series(
 		ctx,
@@ -167,7 +174,7 @@ func (store *LokiStore) GetPodLabelValues(options logstore.LabelValueOptions) ([
 			Start: timestamppb.New(options.Start),
 			End:   timestamppb.New(options.End),
 			Groups: []string{
-				fmt.Sprintf(`{pod=~"%s.*",helm_sh_revision="%s"}`, options.PodPrefix, options.Revision),
+				groupString,
 			},
 		},
 	)


### PR DESCRIPTION
## Description

This PR implements logic to track pod for the logs filter based on the currently selected revision