### PR TITLE
[POR-829] Delete older events for distinct release name, namespace pairs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ COPY /api ./api
 COPY /cli ./cli
 COPY /internal ./internal
 COPY /pkg ./pkg
+COPY /migrate ./migrate
 
 
 # Go build environment
@@ -26,6 +27,7 @@ ARG version=production
 
 RUN go build -a -o ./bin/agent .
 RUN go build -a -o ./bin/agent-cli ./cli
+RUN go build -a -o ./bin/migrate ./migrate
 
 # Deployment environment
 # ----------------------
@@ -34,6 +36,7 @@ RUN apk update && apk add --no-cache curl
 
 COPY --from=build-go /porter/bin/agent /porter/
 COPY --from=build-go /porter/bin/agent-cli /porter/
+COPY --from=build-go /porter/bin/migrate /porter/
 
 ENV SERVER_PORT=10001
 ENV SERVER_TIMEOUT_READ=5s
@@ -41,4 +44,4 @@ ENV SERVER_TIMEOUT_WRITE=10s
 ENV SERVER_TIMEOUT_IDLE=15s
 
 EXPOSE 10001
-CMD /porter/agent
+CMD /porter/migrate && /porter/agent

--- a/internal/repository/event.go
+++ b/internal/repository/event.go
@@ -99,6 +99,8 @@ type ReleaseInfo struct {
 }
 
 func (r *EventRepository) DeleteOlderEvents(l *logger.Logger) {
+	l.Info().Caller().Msgf("cleaning up old events")
+
 	var distinctReleases []ReleaseInfo
 
 	if err := r.db.Model(&models.Event{}).Distinct().Find(&distinctReleases).Error; err != nil {
@@ -122,4 +124,6 @@ func (r *EventRepository) DeleteOlderEvents(l *logger.Logger) {
 	}
 
 	wg.Wait()
+
+	l.Info().Caller().Msgf("finished cleaning up old events")
 }

--- a/internal/repository/event.go
+++ b/internal/repository/event.go
@@ -107,7 +107,6 @@ func (r *EventRepository) DeleteOlderEvents(l *logger.Logger) {
 	}
 
 	var wg sync.WaitGroup
-	// maxEvents := 100
 
 	for _, info := range distinctReleases {
 		wg.Add(1)

--- a/internal/repository/event.go
+++ b/internal/repository/event.go
@@ -116,7 +116,7 @@ func (r *EventRepository) DeleteOlderEvents(l *logger.Logger) {
 		go func(info ReleaseInfo) {
 			defer wg.Done()
 
-			if err := r.db.Exec(`delete from events where id in(select id from (select id, release_name, release_namespace, row_number() over (partition by release_name, release_namespace order by timestamp desc) as rank from events ORDER BY timestamp desc) where rank > 100);`).Error; err != nil {
+			if err := r.db.Exec(`DELETE FROM events WHERE (release_name = ? AND release_namespace = ?) AND id NOT IN (SELECT id FROM events e2 WHERE (e2.release_name = ? AND e2.release_namespace = ?) ORDER BY e2.timestamp desc LIMIT 100)`, info.ReleaseName, info.ReleaseNamespace, info.ReleaseName, info.ReleaseNamespace).Error; err != nil {
 				l.Error().Caller().Msgf("error deleting older events for release %s, namespace %s: %v",
 					info.ReleaseName, info.ReleaseNamespace, err)
 			}

--- a/internal/repository/event.go
+++ b/internal/repository/event.go
@@ -1,6 +1,10 @@
 package repository
 
 import (
+	"fmt"
+	"log"
+	"sync"
+
 	"github.com/porter-dev/porter-agent/internal/models"
 	"github.com/porter-dev/porter-agent/internal/utils"
 	"gorm.io/gorm"
@@ -86,6 +90,73 @@ func (r *EventRepository) DeleteEvent(uid string) error {
 	if err := r.db.Delete(incident).Error; err != nil {
 		return err
 	}
+
+	return nil
+}
+
+type ReleaseInfo struct {
+	ReleaseName      string
+	ReleaseNamespace string
+}
+
+func (r *EventRepository) DeleteOlderEvents() error {
+	var distinctReleases []ReleaseInfo
+
+	if err := r.db.Model(&models.Event{}).Distinct().Find(&distinctReleases).Error; err != nil {
+		return fmt.Errorf("error fetching distinct release name, namespace pairs: %w", err)
+	}
+
+	var wg sync.WaitGroup
+	maxEvents := 100
+
+	for _, info := range distinctReleases {
+		wg.Add(1)
+
+		go func(info ReleaseInfo) {
+			defer wg.Done()
+
+			var count int64
+
+			if err := r.db.Model(&models.Event{}).
+				Where("release_name = ? AND release_namespace = ?", info.ReleaseName, info.ReleaseNamespace).
+				Count(&count).Error; err != nil {
+				log.Printf("error counting events for release %s, namespace %s: %v",
+					info.ReleaseName, info.ReleaseNamespace, err)
+				return
+			}
+
+			if count <= int64(maxEvents) {
+				return
+			}
+
+			log.Printf("deleting older events for release %s, namespace %s", info.ReleaseName, info.ReleaseNamespace)
+
+			for i := 1; i < (int(count)/maxEvents)+1; i++ {
+				var events []*models.Event
+
+				if err := r.db.Model(&models.Event{}).
+					Where("release_name = ? AND release_namespace = ?", info.ReleaseName, info.ReleaseNamespace).
+					Order("timestamp DESC").
+					Limit(maxEvents).
+					Offset(i * maxEvents).
+					Find(&events).
+					Error; err != nil {
+					log.Printf("error fetching events for release %s, namespace %s: %v",
+						info.ReleaseName, info.ReleaseNamespace, err)
+					continue
+				}
+
+				for _, ev := range events {
+					if err := r.db.Delete(ev).Error; err != nil {
+						log.Printf("error deleting event %d for release %s, namespace %s: %v",
+							ev.ID, info.ReleaseName, info.ReleaseNamespace, err)
+					}
+				}
+			}
+		}(info)
+	}
+
+	wg.Wait()
 
 	return nil
 }

--- a/internal/repository/event.go
+++ b/internal/repository/event.go
@@ -147,7 +147,8 @@ func (r *EventRepository) DeleteOlderEvents() error {
 				}
 
 				for _, ev := range events {
-					if err := r.db.Delete(ev).Error; err != nil {
+					// use GORM's Unscoped().Delete() to permanently delete the row from the DB
+					if err := r.db.Unscoped().Delete(ev).Error; err != nil {
 						log.Printf("error deleting event %d for release %s, namespace %s: %v",
 							ev.ID, info.ReleaseName, info.ReleaseNamespace, err)
 					}

--- a/internal/repository/event_cache.go
+++ b/internal/repository/event_cache.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"time"
 
+	"github.com/porter-dev/porter-agent/internal/logger"
 	"github.com/porter-dev/porter-agent/internal/models"
 	"gorm.io/gorm"
 )
@@ -46,4 +47,26 @@ func (r *EventCacheRepository) ListEventCachesForPod(name, namespace string) ([]
 	}
 
 	return caches, nil
+}
+
+func (r *EventCacheRepository) DeleteOlderEventCaches(l *logger.Logger) {
+	l.Info().Caller().Msgf("cleaning up old event caches")
+
+	var olderCache []*models.EventCache
+
+	if err := r.db.Model(&models.EventCache{}).Where("timestamp <= ?", time.Now().Add(-time.Hour)).Find(&olderCache).Error; err == nil {
+		numDeleted := 0
+
+		for _, cache := range olderCache {
+			// use GORM's Unscoped().Delete() to permanently delete the row from the DB
+			if err := r.db.Unscoped().Delete(cache).Error; err != nil {
+				l.Error().Caller().Msgf("error deleting old event cache with ID: %d. Error: %v", cache.ID, err)
+				numDeleted++
+			}
+		}
+
+		l.Info().Caller().Msgf("deleted %d event cache objects from database", numDeleted)
+	} else {
+		l.Error().Caller().Msgf("error querying for older event cache DB entries: %v", err)
+	}
 }

--- a/internal/repository/event_test.go
+++ b/internal/repository/event_test.go
@@ -1,0 +1,66 @@
+package repository
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/porter-dev/porter-agent/internal/models"
+	"github.com/porter-dev/porter-agent/internal/utils"
+)
+
+func TestDeleteOlderEvents(t *testing.T) {
+	tester := &tester{
+		dbFileName: "./event_test.db",
+	}
+
+	setupTestEnv(tester, t)
+	defer cleanup(tester, t)
+
+	// create events for 10 distinct release name, namespace pairs
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("release-%d", i+1)
+		namespace := fmt.Sprintf("namespace-%d", i+1)
+
+		for j := 0; j < 200; j++ {
+			timeNow := time.Now()
+
+			_, err := tester.repo.Event.CreateEvent(&models.Event{
+				ReleaseName:      name,
+				ReleaseNamespace: namespace,
+				UniqueID:         fmt.Sprintf("unique-id-%d-%d", i+1, j+1),
+				Timestamp:        &timeNow,
+			})
+
+			if err != nil {
+				t.Fatalf("Expected no error after creating event, got %v", err)
+			}
+		}
+	}
+
+	// delete older events
+	err := tester.repo.Event.DeleteOlderEvents()
+
+	if err != nil {
+		t.Fatalf("Expected no error after deleting older events, got %v", err)
+	}
+
+	// check that there are 100 events for each release name, namespace pair
+	for i := 0; i < 10; i++ {
+		name := fmt.Sprintf("release-%d", i+1)
+		namespace := fmt.Sprintf("namespace-%d", i+1)
+
+		events, _, err := tester.repo.Event.ListEvents(&utils.ListEventsFilter{
+			ReleaseName:      &name,
+			ReleaseNamespace: &namespace,
+		}, utils.WithLimit(200)) // set a limit of 200 to check that there are no more than 100 events
+
+		if err != nil {
+			t.Fatalf("Expected no error after listing events for release %s, namespace %s, got %v", name, namespace, err)
+		}
+
+		if len(events) != 100 {
+			t.Fatalf("Expected 100 events for release %s, namespace %s, got %d", name, namespace, len(events))
+		}
+	}
+}

--- a/internal/repository/event_test.go
+++ b/internal/repository/event_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/porter-dev/porter-agent/internal/logger"
 	"github.com/porter-dev/porter-agent/internal/models"
 	"github.com/porter-dev/porter-agent/internal/utils"
 )
@@ -38,12 +39,10 @@ func TestDeleteOlderEvents(t *testing.T) {
 		}
 	}
 
-	// delete older events
-	err := tester.repo.Event.DeleteOlderEvents()
+	l := logger.NewConsole(false)
 
-	if err != nil {
-		t.Fatalf("Expected no error after deleting older events, got %v", err)
-	}
+	// delete older events
+	tester.repo.Event.DeleteOlderEvents(l)
 
 	// check that there are 100 events for each release name, namespace pair
 	for i := 0; i < 10; i++ {

--- a/internal/repository/event_test.go
+++ b/internal/repository/event_test.go
@@ -61,5 +61,13 @@ func TestDeleteOlderEvents(t *testing.T) {
 		if len(events) != 100 {
 			t.Fatalf("Expected 100 events for release %s, namespace %s, got %d", name, namespace, len(events))
 		}
+
+		// check that the most recent 100 events are the ones that still exist
+		for j := 0; j < 100; j++ {
+			if events[j].UniqueID != fmt.Sprintf("unique-id-%d-%d", i+1, j+101) {
+				t.Fatalf("Expected event with unique id unique-id-%d-%d to be the %dth event for release %s, namespace %s, got %s",
+					i+1, j+101, j+1, name, namespace, events[j].UniqueID)
+			}
+		}
 	}
 }

--- a/main.go
+++ b/main.go
@@ -236,7 +236,8 @@ func cleanupEventCache(db *gorm.DB, l *logger.Logger) {
 			numDeleted := 0
 
 			for _, cache := range olderCache {
-				if err := db.Delete(cache).Error; err != nil {
+				// use GORM's Unscoped().Delete() to permanently delete the row from the DB
+				if err := db.Unscoped().Delete(cache).Error; err != nil {
 					l.Error().Caller().Msgf("error deleting old event cache with ID: %d. Error: %v\n", cache.ID, err)
 					numDeleted++
 				}

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+
+	"github.com/joeshaw/envdecode"
 	"github.com/porter-dev/porter-agent/internal/adapter"
 	"github.com/porter-dev/porter-agent/internal/envconf"
 	"github.com/porter-dev/porter-agent/internal/logger"
@@ -9,6 +12,12 @@ import (
 
 func main() {
 	envDecoderConf := envconf.EnvDecoderConf{}
+
+	if err := envdecode.StrictDecode(&envDecoderConf); err != nil {
+		logger.NewErrorConsole(true).Fatal().Caller().Msgf("could not decode env conf: %v", err)
+		os.Exit(1)
+	}
+
 	l := logger.NewConsole(envDecoderConf.Debug)
 	db, err := adapter.New(&envDecoderConf.DBConf)
 

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"github.com/porter-dev/porter-agent/internal/adapter"
+	"github.com/porter-dev/porter-agent/internal/envconf"
+	"github.com/porter-dev/porter-agent/internal/logger"
+	"github.com/porter-dev/porter-agent/internal/repository"
+)
+
+func main() {
+	envDecoderConf := envconf.EnvDecoderConf{}
+	l := logger.NewConsole(envDecoderConf.Debug)
+	db, err := adapter.New(&envDecoderConf.DBConf)
+
+	if err != nil {
+		l.Fatal().Caller().Msgf("could not create database connection: %v", err)
+	}
+
+	err = repository.AutoMigrate(db, false)
+
+	if err != nil {
+		l.Fatal().Caller().Msgf("auto migration failed: %v", err)
+	}
+
+	repo := repository.NewRepository(db)
+
+	repo.Event.DeleteOlderEvents(l)
+	repo.EventCache.DeleteOlderEventCaches(l)
+}


### PR DESCRIPTION
Keep only the most recent 100 events for every distinct release name, namespace pair.

- Fetch all distinct release name, namespace pairs
- For every such pair, fetch events in the DB sorting them by timestamp DESC
- If the number of events exceeds 100, then delete every event older than the most recent 100

This will be done every hour.